### PR TITLE
Feat: Add default github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,48 +1,122 @@
 name: Bug report
-description: Report reproducible incorrect behavior
+description: Report reproducible behavior that does not work as expected
 title: "[Bug]: "
-labels: [bug]
+labels:
+  - bug
 body:
   - type: markdown
     attributes:
-      value: Thanks for reporting a bug. For vulnerabilities, follow SECURITY.md instead.
-  - type: input
-    id: bundle-version
+      value: |
+        Thank you for taking the time to report a bug.
+
+        Before submitting, search the existing issues and make sure the problem is caused by this bundle. **Do not disclose security vulnerabilities or include credentials, personal data, or production datasets here.** Use the private security reporting link instead.
+
+  - type: checkboxes
+    id: checks
     attributes:
-      label: Bundle version
-      placeholder: v2.0.1
+      label: Before submitting
+      options:
+        - label: I searched the existing issues and did not find a duplicate.
+          required: true
+        - label: I reproduced the issue with a supported version of the bundle.
+          required: true
+        - label: This report does not contain a security vulnerability or sensitive data.
+          required: true
+
+  - type: dropdown
+    id: operation
+    attributes:
+      label: Affected operation
+      description: Which part of the bundle is affected?
+      options:
+        - Import
+        - Export
+        - Import template generation
+        - Configuration or dependency injection
+        - Other
     validations:
       required: true
-  - type: input
-    id: environment
-    attributes:
-      label: PHP, Symfony, and Doctrine versions
-      placeholder: PHP 8.3, Symfony 7.4, Doctrine ORM 3.5
-    validations:
-      required: true
+
   - type: dropdown
     id: format
     attributes:
       label: File format
-      options: [CSV, XLSX, Not format-specific]
+      options:
+        - CSV
+        - XLSX
+        - Both CSV and XLSX
+        - Not applicable
     validations:
       required: true
+
   - type: textarea
-    id: reproduce
+    id: versions
+    attributes:
+      label: Package versions
+      description: Run `composer show hugoseigle/symfony-import-export-bundle php symfony/framework-bundle doctrine/orm phpoffice/phpspreadsheet` and paste the relevant versions.
+      placeholder: |
+        symfony-import-export-bundle: 2.x.x
+        PHP: 8.x.x
+        Symfony: 7.x.x
+        Doctrine ORM: 3.x.x
+        PhpSpreadsheet: 2.x.x
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Runtime environment
+      description: Operating system and relevant runtime details.
+      placeholder: Ubuntu 24.04, PHP-FPM
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem description
+      description: Clearly describe what goes wrong and when.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
     attributes:
       label: Minimal reproduction
-      description: Include configuration and code, but no sensitive data.
+      description: Provide the smallest configuration and PHP code that reproduce the issue. Use synthetic data only.
+      placeholder: |
+        1. Configure an importer for ...
+        2. Import/export a synthetic file containing ...
+        3. Observe ...
     validations:
       required: true
+
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Bundle configuration
+      description: Paste the relevant sanitized configuration, if applicable.
+      render: yaml
+
   - type: textarea
     id: expected
     attributes:
       label: Expected behavior
+      description: What did you expect to happen?
     validations:
       required: true
+
   - type: textarea
     id: actual
     attributes:
-      label: Actual behavior and stack trace
+      label: Actual behavior and logs
+      description: What happened instead? Include the full exception and stack trace when useful, after removing sensitive data.
     validations:
       required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add any other useful context, such as whether the demo application reproduces the issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/HugoSEIGLE/symfony-import-export-bundle#readme
+    about: Check the guides, supported versions, and examples before opening an issue.
+  - name: Security vulnerability
+    url: https://github.com/HugoSEIGLE/symfony-import-export-bundle/security/advisories/new
+    about: Report vulnerabilities privately. Never disclose security details in a public issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,59 @@
+name: Documentation improvement
+description: Report missing, unclear, or incorrect documentation
+title: "[Docs]: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for helping make the documentation clearer.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues and did not find a duplicate.
+          required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link to the page or provide the file and section name.
+      placeholder: docs/import.md — Error handling
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Type of improvement
+      options:
+        - Incorrect information
+        - Missing information
+        - Unclear explanation
+        - Broken example or link
+        - New guide or example
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What needs to change?
+      description: Explain what is incorrect, missing, or difficult to understand.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: Describe or draft the wording, example, or structure you propose.
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add any other relevant details.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,29 +1,93 @@
 name: Feature request
-description: Propose a focused improvement
+description: Suggest an improvement or a new capability for the bundle
 title: "[Feature]: "
-labels: [enhancement]
+labels:
+  - enhancement
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting an improvement. Please focus on the problem to solve and explain how it fits an import/export bundle rather than an application-specific workflow.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues and did not find an equivalent request.
+          required: true
+        - label: I checked the documentation and current extension points.
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Feature area
+      options:
+        - Import
+        - Export
+        - Import template generation
+        - Configuration
+        - Validation and error handling
+        - Documentation
+        - Performance
+        - Other
+    validations:
+      required: true
+
   - type: textarea
     id: problem
     attributes:
       label: Problem to solve
-      description: Describe the application need, not only a preferred implementation.
+      description: Describe the use case, limitation, or recurring difficulty. Examples are welcome.
     validations:
       required: true
+
   - type: textarea
-    id: proposal
+    id: solution
     attributes:
-      label: Proposed behavior
+      label: Proposed solution
+      description: Explain the API, configuration, or behavior you would like to see.
     validations:
       required: true
+
   - type: textarea
     id: alternatives
     attributes:
       label: Alternatives considered
+      description: Describe any workarounds, service decoration, form transformers, or other approaches you considered.
+
   - type: dropdown
     id: compatibility
     attributes:
-      label: Could this require a breaking API change?
-      options: ['No', 'Unsure', 'Yes']
+      label: Backward compatibility
+      description: Would the proposal require users to change existing code or configuration?
+      options:
+        - No, it is backward compatible
+        - Yes, it may require changes
+        - I am not sure
     validations:
       required: true
+
+  - type: textarea
+    id: api_example
+    attributes:
+      label: Example usage
+      description: Show how the proposed API or configuration could look, if applicable.
+      render: php
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Are you willing to help implement this feature?
+      options:
+        - Yes, I can submit a pull request
+        - Yes, with guidance
+        - No
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add links, examples, or other context that helps explain the request.


### PR DESCRIPTION
## Summary

Describe the problem and the chosen solution.

## Verification

- [ ] `composer validate --strict`
- [ ] `composer dump-autoload --optimize --strict-psr`
- [ ] `composer test`
- [ ] `composer lint`
- [ ] `composer phpstan`
- [ ] Documentation and `CHANGELOG.md` are updated when public behavior changes
- [ ] No production dependency or breaking API change was introduced without justification
